### PR TITLE
remove zuul from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,8 +63,7 @@
     "lodash": "^4.17.4",
     "mocha": "^3.2.0",
     "plato": "^1.7.0",
-    "run-sequence": "^1.2.2",
-    "zuul": "^3.11.1"
+    "run-sequence": "^1.2.2"
   }
 }
 


### PR DESCRIPTION
This (unused!) module is causing security vulnerabilities with downstream dependencies as this version of zuul (the latest to date) depends on express==3.4.8, which in turn depends on send==0.1.4, which has 2 CVEs out and is considered a high-risk vulnerability.

* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-8859
* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-6394